### PR TITLE
Use environment variable for VoiceVox URL and ensure recordings directory creation

### DIFF
--- a/stackchan_server/ws_proxy.py
+++ b/stackchan_server/ws_proxy.py
@@ -67,7 +67,8 @@ class _WsMsgType(IntEnum):
 
 
 def create_voicevox_client() -> VVClient:
-    return VVClient(base_uri="http://localhost:50021")
+    voicevox_url = os.getenv("STACKCHAN_VOICEVOX_URL", "http://localhost:50021")
+    return VVClient(base_uri=voicevox_url)
 
 
 class WsProxy:

--- a/stackchan_server/ws_proxy.py
+++ b/stackchan_server/ws_proxy.py
@@ -20,7 +20,6 @@ logger = getLogger(__name__)
 
 _BASE_DIR = Path(__file__).resolve().parent
 _RECORDINGS_DIR = _BASE_DIR / "recordings"
-_RECORDINGS_DIR.mkdir(parents=True, exist_ok=True)
 
 _WS_HEADER_FMT = "<BBBHH"  # kind, msg_type, reserved, seq, payload_bytes
 _WS_HEADER_SIZE = struct.calcsize(_WS_HEADER_FMT)
@@ -78,6 +77,7 @@ class WsProxy:
         self.recordings_dir = _RECORDINGS_DIR
         self._debug_recording = _DEBUG_RECORDING_ENABLED
         if self._debug_recording:
+            _RECORDINGS_DIR.mkdir(parents=True, exist_ok=True)
             self.recordings_dir.mkdir(parents=True, exist_ok=True)
 
         self._pcm_buffer = bytearray()


### PR DESCRIPTION
This pull request makes improvements to the `stackchan_server/ws_proxy.py` module to enhance configurability and fix directory creation logic. The most important changes are grouped below:

**Configuration Improvements:**

* The `create_voicevox_client` function now allows the Voicevox server URL to be set via the `STACKCHAN_VOICEVOX_URL` environment variable, making it easier to configure the server location without modifying code.

**Directory Management Fixes:**

* The `recordings` directory is now only created when debug recording is enabled, preventing unnecessary directory creation. The logic for creating the directory has been moved from the module level to the `WsProxy` class's initialization, ensuring it is only created when needed. [[1]](diffhunk://#diff-be44ce1fe9588e825d2702681abec233f06bf6b5420794df597a60b567380fceL23) [[2]](diffhunk://#diff-be44ce1fe9588e825d2702681abec233f06bf6b5420794df597a60b567380fceR80)