### PR TITLE
Add Web API endpoints for StackChan state and wakeword management

### DIFF
--- a/stackchan_server/app.py
+++ b/stackchan_server/app.py
@@ -4,7 +4,8 @@ import asyncio
 from logging import getLogger
 from typing import Awaitable, Callable, Optional
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
 
 from .speech_recognition import create_speech_recognizer
 from .speech_synthesis import create_speech_synthesizer
@@ -12,6 +13,15 @@ from .types import SpeechRecognizer, SpeechSynthesizer
 from .ws_proxy import WsProxy
 
 logger = getLogger(__name__)
+
+
+class StackChanInfo(BaseModel):
+    ip: str
+    state: str
+
+
+class SpeakRequest(BaseModel):
+    text: str
 
 
 class StackChanApp:
@@ -25,6 +35,7 @@ class StackChanApp:
         self.fastapi = FastAPI(title="StackChan WebSocket Server")
         self._setup_fn: Optional[Callable[[WsProxy], Awaitable[None]]] = None
         self._talk_session_fn: Optional[Callable[[WsProxy], Awaitable[None]]] = None
+        self._proxies: dict[str, WsProxy] = {}
 
         @self.fastapi.get("/health")
         async def _health() -> dict[str, str]:
@@ -33,6 +44,34 @@ class StackChanApp:
         @self.fastapi.websocket("/ws/stackchan")
         async def _ws_audio(websocket: WebSocket):
             await self._handle_ws(websocket)
+
+        @self.fastapi.get("/v1/stackchan", response_model=list[StackChanInfo])
+        async def _list_stackchans():
+            return [
+                StackChanInfo(ip=ip, state=proxy.current_state.name.lower())
+                for ip, proxy in self._proxies.items()
+            ]
+
+        @self.fastapi.get("/v1/stackchan/{stackchan_ip}", response_model=StackChanInfo)
+        async def _get_stackchan(stackchan_ip: str):
+            proxy = self._proxies.get(stackchan_ip)
+            if proxy is None:
+                raise HTTPException(status_code=404, detail="stackchan not connected")
+            return StackChanInfo(ip=stackchan_ip, state=proxy.current_state.name.lower())
+
+        @self.fastapi.post("/v1/stackchan/{stackchan_ip}/wakeword", status_code=204)
+        async def _trigger_wakeword(stackchan_ip: str):
+            proxy = self._proxies.get(stackchan_ip)
+            if proxy is None:
+                raise HTTPException(status_code=404, detail="stackchan not connected")
+            proxy.trigger_wakeword()
+
+        @self.fastapi.post("/v1/stackchan/{stackchan_ip}/speak", status_code=204)
+        async def _speak(stackchan_ip: str, body: SpeakRequest):
+            proxy = self._proxies.get(stackchan_ip)
+            if proxy is None:
+                raise HTTPException(status_code=404, detail="stackchan not connected")
+            await proxy.speak(body.text)
 
     def setup(self, fn: Callable[["WsProxy"], Awaitable[None]]):
         self._setup_fn = fn
@@ -44,11 +83,21 @@ class StackChanApp:
 
     async def _handle_ws(self, websocket: WebSocket) -> None:
         await websocket.accept()
+        client_ip = websocket.client.host if websocket.client else "unknown"
+
+        # 同一 IP からの既存接続があれば切断する
+        existing = self._proxies.get(client_ip)
+        if existing is not None:
+            logger.info("Duplicate connection from %s, closing old one", client_ip)
+            await existing.close()
+            self._proxies.pop(client_ip, None)
+
         proxy = WsProxy(
             websocket,
             speech_recognizer=self.speech_recognizer,
             speech_synthesizer=self.speech_synthesizer,
         )
+        self._proxies[client_ip] = proxy
         await proxy.start()
         try:
             if self._setup_fn:
@@ -82,6 +131,7 @@ class StackChanApp:
             pass
         finally:
             await proxy.close()
+            self._proxies.pop(client_ip, None)
 
     def run(self, host: str = "0.0.0.0", port: int = 8000, reload: bool = True) -> None:
         import uvicorn

--- a/stackchan_server/ws_proxy.py
+++ b/stackchan_server/ws_proxy.py
@@ -100,14 +100,24 @@ class WsProxy:
         self._closed = False
 
         self._down_seq = 0
+        self._current_firmware_state: FirmwareState = FirmwareState.IDLE
 
     @property
     def closed(self) -> bool:
         return self._closed
 
     @property
+    def current_state(self) -> FirmwareState:
+        return self._current_firmware_state
+
+    @property
     def receive_task(self) -> Optional[asyncio.Task]:
         return self._receiving_task
+
+    def trigger_wakeword(self) -> None:
+        """Web API から擬似的に WAKEWORD_EVT を発火させる。"""
+        logger.info("Triggered wakeword via API")
+        self._wakeword_event.set()
 
     async def wait_for_talk_session(self) -> None:
         while True:
@@ -232,6 +242,7 @@ class WsProxy:
         raw_state = int(payload[0])
         try:
             state = FirmwareState(raw_state)
+            self._current_firmware_state = state
             logger.info("Received firmware state=%s(%d)", state.name, raw_state)
         except ValueError:
             logger.info("Received firmware state=%d", raw_state)


### PR DESCRIPTION
This pull request adds a REST API to the `stackchan_server` for managing and monitoring StackChan devices, and introduces internal state tracking for connected clients. The main changes include new API endpoints for listing, inspecting, and controlling StackChan devices, as well as enhancements to connection management and state synchronization.

**REST API additions:**

* Added new REST API endpoints to `stackchan_server/app.py` for:
  - Listing all connected StackChan devices (`/v1/stackchan`)
  - Retrieving the state of a specific StackChan (`/v1/stackchan/{stackchan_ip}`)
  - Triggering the wakeword event on a StackChan via API (`/v1/stackchan/{stackchan_ip}/wakeword`)
  - Sending a text-to-speech request to a StackChan (`/v1/stackchan/{stackchan_ip}/speak`)
  - Introduced `StackChanInfo` and `SpeakRequest` Pydantic models for request/response validation [[1]](diffhunk://#diff-da2645357679adaf5ff352589549ff5464beeb58a24f38583746a32628035907L7-R8) [[2]](diffhunk://#diff-da2645357679adaf5ff352589549ff5464beeb58a24f38583746a32628035907R18-R26) [[3]](diffhunk://#diff-da2645357679adaf5ff352589549ff5464beeb58a24f38583746a32628035907R48-R75)

**Connection and state management improvements:**

* Implemented a `_proxies` dictionary in `StackChanApp` to track active WebSocket connections by client IP, enabling the new REST endpoints and device management features
* Enhanced connection handling to automatically disconnect any existing connection from the same IP before accepting a new one, ensuring only one active connection per device [[1]](diffhunk://#diff-da2645357679adaf5ff352589549ff5464beeb58a24f38583746a32628035907R86-R100) [[2]](diffhunk://#diff-da2645357679adaf5ff352589549ff5464beeb58a24f38583746a32628035907R134)

**StackChan state tracking and control:**

* Added `current_state` property and internal state tracking to `WsProxy`, synchronizing the firmware state with the server whenever a state event is received [[1]](diffhunk://#diff-be44ce1fe9588e825d2702681abec233f06bf6b5420794df597a60b567380fceR103-R121) [[2]](diffhunk://#diff-be44ce1fe9588e825d2702681abec233f06bf6b5420794df597a60b567380fceR245)
* Added `trigger_wakeword` method to `WsProxy` to allow the REST API to simulate a wakeword event programmatically