### PR TITLE
Refactor microphone configuration in Listening and WakeUpWord

### DIFF
--- a/firmware/src/listening.cpp
+++ b/firmware/src/listening.cpp
@@ -36,11 +36,6 @@ void Listening::init()
 
 void Listening::begin()
 {
-  auto mic_cfg = M5.Mic.config();
-  mic_cfg.sample_rate = 16000;
-  mic_cfg.stereo = false;
-  // mic_cfg.over_sampling = 4;
-  M5.Mic.config(mic_cfg);
   M5.Mic.begin();
   startStreaming();
 }

--- a/firmware/src/listening.cpp
+++ b/firmware/src/listening.cpp
@@ -6,7 +6,7 @@
 
 Listening::Listening(WebSocketsClient &ws, StateMachine &sm, int sampleRate)
     : ws_(ws), state_(sm), sample_rate_(sampleRate),
-      chunk_samples_(static_cast<size_t>(sampleRate) / 2),
+      chunk_samples_(static_cast<size_t>(sampleRate) / 8),
       ring_capacity_samples_(static_cast<size_t>(sampleRate) * 2)
 {
 }
@@ -36,6 +36,11 @@ void Listening::init()
 
 void Listening::begin()
 {
+  auto mic_cfg = M5.Mic.config();
+  mic_cfg.sample_rate = 16000;
+  mic_cfg.stereo = false;
+  // mic_cfg.over_sampling = 4;
+  M5.Mic.config(mic_cfg);
   M5.Mic.begin();
   startStreaming();
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -240,6 +240,7 @@ void setup()
   auto mic_cfg = M5.Mic.config();
   mic_cfg.sample_rate = SAMPLE_RATE;
   mic_cfg.stereo = false;
+  // mic_cfg.over_sampling = 4;
   M5.Mic.config(mic_cfg);
 
   listening.init();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -239,6 +239,7 @@ void setup()
   M5.begin(cfg);
   auto mic_cfg = M5.Mic.config();
   mic_cfg.sample_rate = SAMPLE_RATE;
+  mic_cfg.dma_buf_len = 256;
   mic_cfg.stereo = false;
   // mic_cfg.over_sampling = 4;
   M5.Mic.config(mic_cfg);

--- a/firmware/src/wake_up_word.cpp
+++ b/firmware/src/wake_up_word.cpp
@@ -19,11 +19,6 @@ void WakeUpWord::init()
 
 void WakeUpWord::begin()
 {
-  auto mic_cfg = M5.Mic.config();
-  mic_cfg.sample_rate = 16000;
-  mic_cfg.stereo = false;
-  // mic_cfg.over_sampling = 4;
-  M5.Mic.config(mic_cfg);
   M5.Mic.begin();
   ESP_SR_M5.setMode(SR_MODE_WAKEWORD);
   ESP_SR_M5.resume();

--- a/firmware/src/wake_up_word.cpp
+++ b/firmware/src/wake_up_word.cpp
@@ -19,6 +19,11 @@ void WakeUpWord::init()
 
 void WakeUpWord::begin()
 {
+  auto mic_cfg = M5.Mic.config();
+  mic_cfg.sample_rate = 16000;
+  mic_cfg.stereo = false;
+  // mic_cfg.over_sampling = 4;
+  M5.Mic.config(mic_cfg);
   M5.Mic.begin();
   ESP_SR_M5.setMode(SR_MODE_WAKEWORD);
   ESP_SR_M5.resume();


### PR DESCRIPTION
This pull request makes adjustments to the microphone configuration and audio processing chunk size in the firmware, aiming to optimize audio data handling and improve performance.

Audio processing optimizations:

* Changed the `chunk_samples_` calculation in the `Listening` class to use one-eighth of the sample rate instead of one-half, reducing the size of each processed audio chunk. (`firmware/src/listening.cpp`)

Microphone configuration improvements:

* Set the `dma_buf_len` parameter to 256 in the microphone configuration, which controls the DMA buffer length for audio sampling. (`firmware/src/main.cpp`)
* Added a commented-out option for microphone oversampling, indicating a possible future enhancement. (`firmware/src/main.cpp`)