### PR TITLE
Add disconnected state indicator for firmware startup

### DIFF
--- a/firmware/include/display.hpp
+++ b/firmware/include/display.hpp
@@ -13,7 +13,7 @@ public:
 
 private:
   void drawForState(StateMachine::State state);
-  static uint16_t colorForState(StateMachine::State state);
+  void drawFace();
 
   StateMachine &state_;
   bool has_prev_state_ = false;

--- a/firmware/include/state_machine.hpp
+++ b/firmware/include/state_machine.hpp
@@ -32,7 +32,7 @@ public:
   void addStateExitEvent(State state, Callback cb);
 
 private:
-  State state_ = Idle;
+  State state_ = Disconnected;
   std::array<std::vector<Callback>, 5> entry_events_{};
   std::array<std::vector<Callback>, 5> exit_events_{};
 };

--- a/firmware/include/state_machine.hpp
+++ b/firmware/include/state_machine.hpp
@@ -36,3 +36,5 @@ private:
   std::array<std::vector<Callback>, 5> entry_events_{};
   std::array<std::vector<Callback>, 5> exit_events_{};
 };
+
+const char *stateToString(StateMachine::State state);

--- a/firmware/src/display.cpp
+++ b/firmware/src/display.cpp
@@ -7,6 +7,7 @@ void Display::init()
   M5.Display.clear();
   M5.Display.setTextSize(2);
   drawForState(state_.getState());
+  drawFace();
   has_prev_state_ = true;
   prev_state_ = state_.getState();
 }
@@ -16,7 +17,9 @@ void Display::loop()
   StateMachine::State current = state_.getState();
   if (!has_prev_state_ || current != prev_state_)
   {
+    M5.Display.fillScreen(TFT_BLACK);
     drawForState(current);
+    drawFace();
   }
 
   prev_state_ = current;
@@ -25,9 +28,47 @@ void Display::loop()
 
 void Display::drawForState(StateMachine::State state)
 {
-  uint16_t bg = colorForState(state);
-  M5.Display.fillScreen(bg);
+  uint16_t bg_color;
+  uint16_t font_color;
 
+  switch (state)
+  {
+  case StateMachine::Idle:
+    bg_color = TFT_DARKGRAY;
+    font_color = TFT_WHITE;
+    break;
+  case StateMachine::Listening:
+    bg_color = TFT_BLUE;
+    font_color = TFT_WHITE;
+    break;
+  case StateMachine::Thinking:
+    bg_color = TFT_ORANGE;
+    font_color = TFT_BLACK;
+    break;
+  case StateMachine::Speaking:
+    bg_color = TFT_GREEN;
+    font_color = TFT_BLACK;
+    break;
+  case StateMachine::Disconnected:
+    bg_color = TFT_RED;
+    font_color = TFT_WHITE;
+    break;
+  default:
+    bg_color = TFT_DARKGRAY;
+    font_color = TFT_WHITE;
+    break;
+  }
+
+  M5.Display.fillRect(0, 220, 320, 240, bg_color);
+  M5.Display.setFont(&fonts::Font2);
+  M5.Display.setTextSize(1);
+  M5.Display.setTextColor(font_color, bg_color);
+  M5.Display.setCursor(10, 222);
+  M5.Display.printf("%s", stateToString(state));
+}
+
+void Display::drawFace()
+{
   uint32_t eye_y = 102;
   uint32_t between_eyes = 135;
   uint32_t eye_size = 8;
@@ -37,23 +78,4 @@ void Display::drawForState(StateMachine::State state)
   M5.Display.fillCircle(160 - between_eyes / 2, eye_y, eye_size, TFT_WHITE);
   M5.Display.fillCircle(160 + between_eyes / 2, eye_y, eye_size, TFT_WHITE);
   M5.Display.fillRect(160 - mouth_width / 2, mouth_y, mouth_width, mouth_height, TFT_WHITE);
-}
-
-uint16_t Display::colorForState(StateMachine::State state)
-{
-  switch (state)
-  {
-  case StateMachine::Idle:
-    return TFT_BLACK;
-  case StateMachine::Listening:
-    return TFT_BLUE;
-  case StateMachine::Thinking:
-    return TFT_ORANGE;
-  case StateMachine::Speaking:
-    return TFT_GREEN;
-  case StateMachine::Disconnected:
-    return TFT_RED;
-  default:
-    return TFT_DARKGREY;
-  }
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -40,7 +40,6 @@ namespace
 uint16_t g_uplink_seq = 0;
 uint32_t g_last_comm_ms = 0;
 constexpr uint32_t kCommTimeoutMs = 60000;
-bool g_has_connected_once = false;
 
 void markCommunicationActive()
 {
@@ -184,10 +183,7 @@ void handleWsEvent(WStype_t type, uint8_t *payload, size_t length)
   case WStype_DISCONNECTED:
     // M5.Display.println("WS: disconnected");
     log_i("WS disconnected");
-    if (g_has_connected_once)
-    {
-      stateMachine.setState(StateMachine::Disconnected);
-    }
+    stateMachine.setState(StateMachine::Disconnected);
     break;
   case WStype_CONNECTED:
     // M5.Display.printf("WS: connected %s\n", SERVER_PATH);
@@ -196,7 +192,6 @@ void handleWsEvent(WStype_t type, uint8_t *payload, size_t length)
     {
       stateMachine.setState(StateMachine::Idle);
     }
-    g_has_connected_once = true;
     markCommunicationActive();
     notifyCurrentState(stateMachine.getState());
     break;
@@ -329,9 +324,6 @@ void setup()
   stateMachine.addStateEntryEvent(StateMachine::Thinking, [](StateMachine::State, StateMachine::State) {
     notifyCurrentState(StateMachine::Thinking);
   });
-
-  // initial state setup (Idle)
-  wakeUpWord.begin();
 }
 
 void loop()

--- a/firmware/src/state_machine.cpp
+++ b/firmware/src/state_machine.cpp
@@ -1,8 +1,6 @@
 #include <M5Unified.h>
 #include "state_machine.hpp"
 
-namespace
-{
 const char *stateToString(StateMachine::State s)
 {
 	switch (s)
@@ -20,7 +18,6 @@ const char *stateToString(StateMachine::State s)
 	default:
 		return "Unknown";
 	}
-}
 }
 
 void StateMachine::setState(State s)


### PR DESCRIPTION
## Summary
- add a dedicated `Disconnected` initial state in the firmware state machine
- keep the device in `Disconnected` until the WebSocket connection is established
- update the display/state handling so the startup indicator reflects the real connection state

## Testing
- Built firmware successfully with PlatformIO
