### PR TITLE
Update AGENTS and protocols documentation with REST API specifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,98 +1,114 @@
 # AGENTS 概要
 
-本リポジトリの現行実装（`firmware/` と `stackchan_server/`）の役割と、WebSocket バイナリプロトコルをまとめる。
+本リポジトリの現行実装を素早く把握するためのメモです。詳細仕様は `docs/protocols.md` と `docs/rest-api.md` を参照してください。
 
 ## 全体像
-- 音声経路（上り）: CoreS3 マイク → `AudioPcm` で PCM16LE ストリーミング → サーバー受信 → WAV 保存 → Google Cloud Speech-to-Text。
-- 音声経路（下り）: サーバー側で VOICEVOX 合成 → `AudioWav` で PCM 分割送信 → CoreS3 スピーカー再生。
-- 制御: CoreS3 は `StateMachine` で `Idle` / `Listening` / `Thinking` / `Speaking` を遷移。
-- トリガ: `Idle` 中に WakeWord 検出をサーバーへ通知。`Listening` 遷移はサーバーからの `StateCmd` で開始。`Listening` は無音 3 秒で自動終了。
 
-## WebSocket プロトコル（現行）
-- 共通ヘッダ: `WsHeader`（`firmware/include/protocols.hpp`）
-- 構造（packed, little-endian）: `<B B B H H`
-  - `kind` (`uint8`): 1=`AudioPcm`, 2=`AudioWav`, 3=`StateCmd`, 4=`WakeWordEvt`, 5=`StateEvt`, 6=`SpeakDoneEvt`
-  - `messageType` (`uint8`): 1=`START`, 2=`DATA`, 3=`END`
-  - `reserved` (`uint8`): 0
-  - `seq` (`uint16`): 送信側でインクリメント
-  - `payloadBytes` (`uint16`): ヘッダ直後のバイト数
+- CoreS3 側は `firmware/`、Python サーバー側は `stackchan_server/`。
+- 音声 uplink は `AudioPcm`、音声 downlink は `AudioWav`（実体は raw PCM）。
+- サーバーは FastAPI を公開し、WebSocket と REST API の両方を持つ。
+- サーボ制御が追加済みで、WebSocket プロトコルには `ServoCmd` / `ServoDoneEvt` がある。
 
-### Uplink（CoreS3 -> Server, kind=1 AudioPcm）
-- 形式: PCM16LE / 16kHz / 1ch 固定。
-- シーケンス: `START`（payload なし）→ `DATA` 複数回 → `END`（payload なし）。
-- `Listening` は 0.5 秒相当（8000 samples）ごとに `DATA` 送信。終了時に残りバッファを flush。
+## 状態遷移の要点
 
-### Downlink（Server -> CoreS3, kind=2 AudioWav）
-- 実体は WAV コンテナではなく「PCM 本体のストリーム分割」。
-- 1セグメントの流れ:
-  - `START`: payload `<uint32 sample_rate><uint16 channels>`
-  - `DATA`: raw PCM chunk（既定 4096 bytes）
-  - `END`: payload なし
-- サーバーは合成 PCM を約 2 秒単位でセグメント化し、2 本目を 1 秒後に先行開始して連続再生しやすくしている。
+- ファームウェア状態: `Idle`, `Listening`, `Thinking`, `Speaking`, `Disconnected`
+- サーバーから指示できるのは `StateCmd` の `0..3` (`Idle`〜`Speaking`)
+- `Disconnected` はファームウェア内部状態で、WebSocket 切断時に入る
+- `WakeWordEvt` を受けるか、REST API の wakeword 擬似発火で talk session が始まる
 
-### Downlink（Server -> CoreS3, kind=3 StateCmd）
-- `messageType=DATA` 固定、payload は 1 byte の target state id。
-- state id: `0=Idle`, `1=Listening`, `2=Thinking`, `3=Speaking`。
-- 現在は uplink 音声の `END` 受信直後にサーバーが `Thinking` 指示を送る。
+## WebSocket プロトコル要約
 
-### Uplink（CoreS3 -> Server, kind=4 WakeWordEvt）
-- `messageType=DATA` 固定、payload は 1 byte（`1=detected`）。
-- `Idle` 中の WakeWord 検出通知。サーバー側の対話セッション起動トリガに使う。
+- 共通ヘッダ: `WsHeader` (`<B B B H H>`, packed, little-endian)
+- `kind`
+  - `1=AudioPcm`
+  - `2=AudioWav`
+  - `3=StateCmd`
+  - `4=WakeWordEvt`
+  - `5=StateEvt`
+  - `6=SpeakDoneEvt`
+  - `7=ServoCmd`
+  - `8=ServoDoneEvt`
+- `messageType`
+  - `1=START`
+  - `2=DATA`
+  - `3=END`
 
-### Uplink（CoreS3 -> Server, kind=5 StateEvt）
-- `messageType=DATA` 固定、payload は 1 byte の current state id。
-- state id: `0=Idle`, `1=Listening`, `2=Thinking`, `3=Speaking`。
-- サーバーは状態同期に利用する。
+### 現行挙動
 
-### Uplink（CoreS3 -> Server, kind=6 SpeakDoneEvt）
-- `messageType=DATA` 固定、payload は 1 byte（`1=done`）。
-- `Speaking` の再生完了通知。`Idle` とは独立して発話完了を判定できる。
+- `AudioPcm`
+  - PCM16LE / 16kHz / 1ch
+  - `START -> DATA* -> END`
+  - `DATA` は 2000 samples（4000 bytes, 約 125ms）ごと
+  - 無音 3 秒で自動終了
+- `AudioWav`
+  - 名前に反して WAV コンテナではなく PCM ストリーム
+  - `START` payload は `<uint32 sample_rate><uint16 channels>`
+  - `DATA` chunk は既定 4096 bytes
+  - 約 2 秒セグメントで送信し、2 本目は約 1 秒後に先行開始
+- `ServoCmd`
+  - payload: `<uint8 count><commands...>`
+  - op: `0=Sleep`, `1=MoveX`, `2=MoveY`
+  - 新規コマンド受信時は実行中シーケンスを置き換える
 
-## CoreS3 側（`firmware/`）
-- エントリポイント: `firmware/src/main.cpp`
-  - Wi-Fi 接続後、`/ws/stackchan` に接続。
-  - WS 受信で `kind=AudioWav` を `Speaking` に渡す。
-- `WakeUpWord`（`firmware/src/wake_up_word.cpp`）
-  - `Idle` 中に `ESP_SR_M5` へマイク音声を feed。
-  - WakeWord 検出時は `WakeWordEvt` を送信（自動遷移しない）。
-- `Listening`（`firmware/src/listening.cpp`）
-  - 2 秒リングバッファ、マイク読み取り 256 サンプル単位。
-  - `START/DATA/END` を送信。
-  - 無音閾値（平均絶対値 200 以下）が 3 秒続くと自動停止して `Idle` へ戻る。
-  - 送信失敗時も `Idle` へフォールバック。
-- `Thinking`
-  - サーバーからの `StateCmd` を受けて遷移する待機状態。
-  - 自動遷移はせず、`AudioWav START` または次の状態指示で遷移。
-- `Speaking`（`firmware/src/speaking.cpp`）
-  - `AudioWav` の `START` でメタ情報取得、`DATA` 蓄積、`END` で `M5.Speaker.playRaw` 再生。
-  - 再生完了時に `SpeakDoneEvt` を送信し、その後 `Idle` に戻る。
-- `Display`（`firmware/src/display.cpp`）
-  - 状態色のみ表示: `Idle=黒`, `Listening=青`, `Thinking=オレンジ`, `Speaking=緑`。
+## サーバー側 (`stackchan_server/`)
 
-## サーバー側（`stackchan_server/`）
-- FastAPI 本体: `stackchan_server/app.py`
-  - `GET /health`
-  - `WS /ws/stackchan`
-- WS 処理: `stackchan_server/ws_proxy.py`
-  - 受信 `AudioPcm` を蓄積し、`END` 時に `stackchan_server/recordings/rec_ws_*.wav` として保存。
-  - その PCM を Google Cloud Speech-to-Text（`ja-JP`, LINEAR16, 16kHz）で文字起こし。
-  - `get_message_async()` でアプリ層へ認識結果を渡す。
-  - `start_talking(text)` で VOICEVOX（`http://localhost:50021`, speaker=29）合成し、`AudioWav` として分割送信。
+### `stackchan_server/app.py`
 
-## アプリ層（`example_apps/`）
-- `example_apps/echo.py`: 認識結果をそのまま VOICEVOX で復唱。
-- `example_apps/gemini.py`: 認識結果を Gemini チャットに渡し、応答文を VOICEVOX で発話。
-  - いずれも `@app.talk_session` / `proxy.listen()` / `proxy.speak()` を使用。
+- `GET /health`
+- `WS /ws/stackchan`
+- `GET /v1/stackchan`
+- `GET /v1/stackchan/{stackchan_ip}`
+- `POST /v1/stackchan/{stackchan_ip}/wakeword`
+- `POST /v1/stackchan/{stackchan_ip}/speak`
 
-## 依存・周辺
-- VOICEVOX エンジン: ルート `docker-compose.yml` の `voicevox` サービス（`50021:50021`）。
-- Python 依存: `fastapi`, `uvicorn`, `voicevox-client`, `google-cloud-speech`, `google-genai`。
-- 録音保存先: `stackchan_server/recordings/`（自動生成）。
+### `stackchan_server/ws_proxy.py`
 
-## 期待する動作フロー
-1. VOICEVOX を起動（ルートで `docker compose run --rm --service-ports voicevox` など）。
-2. サーバーを起動（例: `uv run uvicorn app.gemini:app.fastapi --host 0.0.0.0 --port 8000`）。
-3. CoreS3 が Wi-Fi/WS 接続後、`Idle` で WakeWord 待機。
-4. WakeWord 検出をサーバーへ通知。サーバーが `Listening` を指示して録音送信開始。無音 3 秒で送信終了。
-5. サーバーが WAV 保存・文字起こしし、アプリ層の応答文を VOICEVOX 合成。
-6. 合成 PCM が `AudioWav` で返送され、CoreS3 が再生して `Idle` に戻る。
+- 接続ごとに `WsProxy` を作成
+- `websocket.client.host` を StackChan の識別子として使う
+- 同一 IP の再接続時は既存接続を置き換える
+- `listen()` は `Listening` 指示後、音声 uplink 完了を待つ
+- `speak()` は TTS downlink 送信後、`SpeakDoneEvt` を待つ
+- `move_servo()` / `wait_servo_complete()` を公開
+
+### 音声認識 / 音声合成
+
+- 既定 STT: `GoogleCloudSpeechToText`（ストリーミング認識）
+- 既定 TTS: `VoiceVoxSpeechSynthesizer`
+- `example_apps/echo.py` / `echo_with_move.py` は `STACKCHAN_WHISPER_MODEL` があると `whisper.cpp` を使う
+- `DEBUG_RECODING=1` のときのみ録音 WAV と TTS WAV を `stackchan_server/recordings/` に保存する
+  - 実装上この変数名は typo のまま
+
+## ファームウェア側 (`firmware/`)
+
+- `src/main.cpp`
+  - Wi-Fi 接続後、`/ws/stackchan` に接続
+  - `AudioWav`, `StateCmd`, `ServoCmd` を受信処理
+  - 通信が 60 秒止まると `Thinking` / `Speaking` から `Idle` に戻す
+- `src/listening.cpp`
+  - マイク読み取り 256 サンプル単位
+  - 2 秒リングバッファ
+  - 無音 3 秒で停止
+- `src/speaking.cpp`
+  - 3 本バッファで TTS セグメント受信
+  - `END` 後に `M5.Speaker.playRaw()` で再生
+  - 再生完了時に `SpeakDoneEvt`
+- `src/servo.cpp`
+  - `ServoCmd` を非同期実行
+  - `MoveX`, `MoveY`, `Sleep` を順次処理
+  - 完了時に `ServoDoneEvt`
+- `src/display.cpp`
+  - `Idle=濃いグレー`, `Listening=青`, `Thinking=オレンジ`, `Speaking=緑`, `Disconnected=赤`
+
+## サンプルアプリ
+
+- `example_apps/echo.py`: 音声をそのまま復唱
+- `example_apps/echo_with_move.py`: 復唱 + サーボ動作
+- `example_apps/gemini.py`: Gemini 応答を発話
+
+## 起動時の目安
+
+1. VOICEVOX を起動
+2. FastAPI サーバーを `example_apps.*:app.fastapi` で起動
+3. CoreS3 が WebSocket 接続
+4. ウェイクワードまたは REST API の wakeword 呼び出しで対話開始
+5. 必要に応じて発話・サーボ制御を返送

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -2,134 +2,158 @@
 コーディングエージェント向け指示: このディレクトリにはプロトコルのみを記述し、CPP、Pythonの実装コードの例を記述する必要はありません。どんなプロトコルが実装されているか確認するために用います。
 -->
 
-# プロトコル仕様（1 バイト kind / 共通ヘッダ）
+# WebSocket バイナリプロトコル仕様
 
-このドキュメントは、本リポジトリで使われている WebSocket ベースのバイナリプロトコルについて日本語で説明します。CoreS3（ESP32）とサーバー間の送受信で共通のヘッダを使います。
+このドキュメントは、CoreS3 ファームウェアと Python サーバーがやり取りする WebSocket バイナリプロトコルの現行実装をまとめたものです。
 
-## 共通ヘッダ: WsHeader
+## 共通ヘッダ
 
-`include/protocols.hpp` に定義されるヘッダ（packed, LE）:
+共通ヘッダ `WsHeader` は `firmware/include/protocols.hpp` で定義されています。
 
-```cpp
-enum class MessageKind : uint8_t {
-  AudioPcm = 1, // クライアント→サーバ（PCM16LE）
-  AudioWav = 2, // サーバ→クライアント（WAV バイト列）
-  StateCmd = 3, // サーバ→クライアント（状態遷移指示）
-  WakeWordEvt = 4, // クライアント→サーバ（wake word 検知通知）
-  StateEvt = 5, // クライアント→サーバ（現在状態通知）
-  SpeakDoneEvt = 6, // クライアント→サーバ（発話完了通知）
-  ServoCmd = 7, // サーバ→クライアント（サーボ動作シーケンス指示）
-  ServoDoneEvt = 8, // クライアント→サーバ（サーボ動作シーケンス完了通知）
-};
+- packed
+- little-endian
+- 構造: `<B B B H H>`
 
-enum class MessageType : uint8_t {
-  START = 1,
-  DATA = 2,
-  END  = 3,
-};
+| フィールド | 型 | 説明 |
+| --- | --- | --- |
+| `kind` | `uint8` | メッセージ種別 |
+| `messageType` | `uint8` | `1=START`, `2=DATA`, `3=END` |
+| `reserved` | `uint8` | 現在は常に `0` |
+| `seq` | `uint16` | 送信側でインクリメントするシーケンス番号 |
+| `payloadBytes` | `uint16` | ヘッダ直後に続く payload のバイト数 |
 
-struct __attribute__((packed)) WsHeader {
-  uint8_t  kind;         // MessageKind
-  uint8_t  messageType;  // MessageType
-  uint8_t  reserved;     // 0（将来のフラグ用）
-  uint16_t seq;          // シーケンス番号
-  uint16_t payloadBytes; // ヘッダ直後に続くバイト数
-};
-```
+### `kind` 一覧
 
-- バイトオーダー: リトルエンディアン。
-- `seq`: 送信側がインクリメント。整合チェックに使用。
-- `payloadBytes`: ヘッダ直後に続く生データ長（最大 65535）。
+| kind | 名前 | 方向 | 用途 |
+| --- | --- | --- | --- |
+| `1` | `AudioPcm` | CoreS3 → Server | マイク音声 PCM ストリーム |
+| `2` | `AudioWav` | Server → CoreS3 | TTS 音声 PCM ストリーム |
+| `3` | `StateCmd` | Server → CoreS3 | 状態遷移指示 |
+| `4` | `WakeWordEvt` | CoreS3 → Server | ウェイクワード検出通知 |
+| `5` | `StateEvt` | CoreS3 → Server | 現在状態通知 |
+| `6` | `SpeakDoneEvt` | CoreS3 → Server | 音声再生完了通知 |
+| `7` | `ServoCmd` | Server → CoreS3 | サーボ動作シーケンス指示 |
+| `8` | `ServoDoneEvt` | CoreS3 → Server | サーボ動作完了通知 |
 
-### Uplink: kind = AudioPcm (1)
+## `AudioPcm` (`kind=1`)
 
-- 方向: クライアント -> サーバ
-- フォーマット: PCM16LE モノラル、サンプルレート固定 16 kHz（チャンネル数 1）。
-- メッセージの流れ: START (通常 payload 0) → DATA 複数回 → END (payload 0 または残りを含む)。
-- サーバー側は固定パラメータ（16 kHz / ch=1）として WAV に保存し、STT に渡す。
+- 方向: CoreS3 → Server
+- フォーマット: PCM16LE / 16kHz / 1ch
+- シーケンス: `START` → `DATA` 複数回 → `END`
+- `START` payload: なし
+- `DATA` payload: PCM16LE 生データ
+- `END` payload: 現行ファームウェアではなし
 
-### Downlink: kind = AudioWav (2)
+### 現行実装メモ
 
-- 方向: サーバ -> クライアント
-- コンテンツ: PCM16LE を「総サイズなし」でストリーミング分割送信。
-- メッセージの流れ:
-  - START: payload は `<uint32 sample_rate><uint16 channels>`。
-  - DATA: payload に PCM データチャンク（サイズは適宜分割）。
-  - END: payload 0。クライアントは受信完了として再生を開始する。
-- クライアントは START でバッファを初期化し、DATA を順次 append、END で再生。seq で欠損検知は可能（TCP 前提なら警告のみで継続も可）。
+- CoreS3 はマイクを 256 サンプルずつ読み取り、リングバッファに蓄積します。
+- `DATA` は `2000 samples` ごとに送信されます。
+  - 1 chunk = `2000 samples × 2 bytes = 4000 bytes`
+  - 時間長は約 `125 ms`
+- 無音判定は平均絶対振幅 `<= 200` が 3 秒継続したときに発火します。
+- 停止時は未送信サンプルを `DATA` で flush してから `END` を送ります。
 
-### Downlink: kind = StateCmd (3)
+## `AudioWav` (`kind=2`)
 
-- 方向: サーバ -> クライアント
-- メッセージ種別: `DATA` のみ使用
+- 方向: Server → CoreS3
+- 名前は `AudioWav` ですが、実際に送っているのは WAV コンテナではなく PCM16LE ストリームです。
+- 1 セグメントの流れは `START` → `DATA` 複数回 → `END` です。
+
+### payload 形式
+
+| messageType | payload |
+| --- | --- |
+| `START` | `<uint32 sample_rate><uint16 channels>` |
+| `DATA` | PCM16LE 生データ |
+| `END` | なし |
+
+### 現行実装メモ
+
+- Server は合成済み PCM を約 2 秒単位でセグメント分割します。
+- 各 `DATA` chunk は既定で `4096 bytes` です。
+- 2 本目のセグメントは約 1 秒後に送信を開始し、その後は 2 秒刻みで続きます。
+- CoreS3 は 3 本の受信バッファを持ち、`END` 到達後に `M5.Speaker.playRaw()` で再生します。
+- `seq` の欠損は検知しますが、TCP 前提のため再送制御は行いません。
+
+## `StateCmd` (`kind=3`)
+
+- 方向: Server → CoreS3
+- `messageType`: `DATA` のみ
 - payload: 1 byte の target state id
-  - `0=Idle`
-  - `1=Listening`
-  - `2=Thinking`
-  - `3=Speaking`
-- 現行運用: uplink の `END` 受信完了直後に `Thinking` を送信。
 
-### Uplink: kind = WakeWordEvt (4)
+| 値 | 状態 |
+| --- | --- |
+| `0` | `Idle` |
+| `1` | `Listening` |
+| `2` | `Thinking` |
+| `3` | `Speaking` |
 
-- 方向: クライアント -> サーバ
-- メッセージ種別: `DATA` のみ使用
-- payload: 1 byte（`1=detected`）
-- 役割: Idle 中に WakeWord を検知したことを通知し、サーバー側の対話セッション開始トリガに使う。
+### 現行実装メモ
 
-### Uplink: kind = StateEvt (5)
+- `proxy.listen()` 開始時に Server が `Listening` を指示します。
+- 音声 uplink の `END` を受けると、Server は `Thinking` を指示します。
+- `proxy.speak()` 完了後、Server は `Idle` を指示します。
 
-- 方向: クライアント -> サーバ
-- メッセージ種別: `DATA` のみ使用
+## `WakeWordEvt` (`kind=4`)
+
+- 方向: CoreS3 → Server
+- `messageType`: `DATA` のみ
+- payload: 1 byte (`1=detected`)
+- `Idle` 中のウェイクワード検出をサーバー側に通知します。
+- REST API の `POST /v1/stackchan/{ip}/wakeword` は、このイベントをサーバー内部で擬似発火させます。
+
+## `StateEvt` (`kind=5`)
+
+- 方向: CoreS3 → Server
+- `messageType`: `DATA` のみ
 - payload: 1 byte の current state id
-  - `0=Idle`
-  - `1=Listening`
-  - `2=Thinking`
-  - `3=Speaking`
-- 役割: サーバー側で状態同期に利用する。
 
-### Uplink: kind = SpeakDoneEvt (6)
+| 値 | 状態 |
+| --- | --- |
+| `0` | `Idle` |
+| `1` | `Listening` |
+| `2` | `Thinking` |
+| `3` | `Speaking` |
 
-- 方向: クライアント -> サーバ
-- メッセージ種別: `DATA` のみ使用
-- payload: 1 byte（`1=done`）
-- 役割: TTS再生が完了したことを通知する。`Idle` 遷移とは独立に扱える。
+- CoreS3 は状態遷移の entry hook で送信します。
+- WebSocket 切断中は `Disconnected` 状態になりますが、切断時は uplink 送信できないため `StateEvt` では通知されません。
 
-### Downlink: kind = ServoCmd (7)
+## `SpeakDoneEvt` (`kind=6`)
 
-- 方向: サーバー -> クライアント
-- メッセージ種別: `DATA` のみ使用
-- payload: 1 つの「サーボ動作シーケンス」をまとめて送る
-  - `<uint8 command_count>`
-  - 続いて `command_count` 個のコマンド
-    - `Sleep (op=0)`: `<uint8 op><int16 duration_ms>`
-    - `MoveX (op=1)`: `<uint8 op><int8 angle><int16 duration_ms>`
-    - `MoveY (op=2)`: `<uint8 op><int8 angle><int16 duration_ms>`
-- ファームウェアは受信後すぐにキューへ積み、`loop()` 内で非同期に順次実行する。
-- 新しい `ServoCmd` を受信した場合、現在のシーケンスは置き換える。
+- 方向: CoreS3 → Server
+- `messageType`: `DATA` のみ
+- payload: 1 byte (`1=done`)
+- CoreS3 側の音声再生完了を通知します。
+- Server はこの通知を待って `proxy.speak()` を完了させます。
 
-### Uplink: kind = ServoDoneEvt (8)
+## `ServoCmd` (`kind=7`)
 
-- 方向: クライアント -> サーバー
-- メッセージ種別: `DATA` のみ使用
-- payload: 1 byte（`1=done`）
-- 役割: 直前に受信した `ServoCmd` のシーケンス全体が完了したことを通知する。
+- 方向: Server → CoreS3
+- `messageType`: `DATA` のみ
+- payload はサーボ動作シーケンス全体です。
 
-### kind の拡張例
+### payload 構造
 
-- AudioPcm (1): 現行の PCM16LE アップリンク
-- AudioWav (2): WAV ダウンリンク
-- StateCmd (3): 状態遷移指示
-- WakeWordEvt (4): wake word 検知通知
-- StateEvt (5): 現在状態通知
-- SpeakDoneEvt (6): 発話完了通知
-- ServoCmd (7): サーボ動作シーケンス指示
-- ServoDoneEvt (8): サーボ動作シーケンス完了通知
+- 先頭 1 byte: `<uint8 command_count>`
+- 続いて `command_count` 個のコマンド
 
-### 簡易バイト例（AudioPcm / DATA）
+| op | 名前 | payload |
+| --- | --- | --- |
+| `0` | `Sleep` | `<uint8 op><int16 duration_ms>` |
+| `1` | `MoveX` | `<uint8 op><int8 angle><int16 duration_ms>` |
+| `2` | `MoveY` | `<uint8 op><int8 angle><int16 duration_ms>` |
 
-- kind: 0x01
-- messageType: DATA (0x02)
-- reserved: 0x00
-- seq: 0x0005 (LE => 0x05 0x00)
-- payloadBytes: 0x4000 (16384 バイトの PCM)
-- body: 16384 バイトの PCM16LE データ
+### 現行実装メモ
+
+- Python 側では 0〜255 個のコマンドをエンコードできます。
+- `angle` は signed 8-bit で送られますが、ファームウェアでは最終的に `0..180` 度へ clamp されます。
+- `duration_ms <= 0` は即時反映になります。
+- 新しい `ServoCmd` を受けると、実行中シーケンスは置き換えられます。
+
+## `ServoDoneEvt` (`kind=8`)
+
+- 方向: CoreS3 → Server
+- `messageType`: `DATA` のみ
+- payload: 1 byte (`1=done`)
+- 直前に受信したサーボシーケンスの完了通知です。
+- Server は `proxy.wait_servo_complete()` でこの完了を待てます。

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1,0 +1,189 @@
+# REST API 仕様
+
+このドキュメントは、`stackchan_server/app.py` が公開している HTTP API の現行仕様をまとめたものです。
+
+## 概要
+
+- ベース URL 例: `http://localhost:8000`
+- 実装: FastAPI
+- StackChan の識別子: WebSocket 接続元 IP アドレス (`websocket.client.host`)
+- 一覧や取得対象になるのは、現在接続中の StackChan のみです
+
+## エンドポイント一覧
+
+| Method | Path | 説明 |
+| --- | --- | --- |
+| `GET` | `/health` | ヘルスチェック |
+| `GET` | `/v1/stackchan` | 接続中 StackChan 一覧 |
+| `GET` | `/v1/stackchan/{stackchan_ip}` | 指定 StackChan の状態取得 |
+| `POST` | `/v1/stackchan/{stackchan_ip}/wakeword` | 擬似 wakeword 発火 |
+| `POST` | `/v1/stackchan/{stackchan_ip}/speak` | 指定 StackChan に発話させる |
+
+## `GET /health`
+
+サーバーの簡易ヘルスチェックです。
+
+### レスポンス
+
+- Status: `200 OK`
+
+```json
+{
+  "status": "ok"
+}
+```
+
+## `GET /v1/stackchan`
+
+現在接続中の StackChan 一覧を返します。
+
+### レスポンス
+
+- Status: `200 OK`
+
+```json
+[
+  {
+    "ip": "192.168.1.23",
+    "state": "idle"
+  }
+]
+```
+
+### フィールド
+
+| フィールド | 型 | 説明 |
+| --- | --- | --- |
+| `ip` | `string` | WebSocket 接続元 IP |
+| `state` | `string` | 現在状態 |
+
+### `state` の値
+
+現行実装では以下が返りえます。
+
+- `idle`
+- `listening`
+- `thinking`
+- `speaking`
+- `disconnected`
+
+> [!NOTE]
+> 一覧 API では `closed` な接続は除外されるため、通常 `disconnected` が長く残り続けることはありません。
+
+## `GET /v1/stackchan/{stackchan_ip}`
+
+指定した StackChan の現在状態を返します。
+
+### パスパラメータ
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| `stackchan_ip` | `string` | 対象 StackChan の接続元 IP |
+
+### 成功レスポンス
+
+- Status: `200 OK`
+
+```json
+{
+  "ip": "192.168.1.23",
+  "state": "idle"
+}
+```
+
+### エラーレスポンス
+
+- Status: `404 Not Found`
+
+```json
+{
+  "detail": "stackchan not connected"
+}
+```
+
+## `POST /v1/stackchan/{stackchan_ip}/wakeword`
+
+サーバー内部で wakeword イベントを擬似発火し、`talk_session` の開始待ちを解除します。
+
+### パスパラメータ
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| `stackchan_ip` | `string` | 対象 StackChan の接続元 IP |
+
+### リクエストボディ
+
+なし。
+
+### 成功レスポンス
+
+- Status: `204 No Content`
+
+### エラーレスポンス
+
+- Status: `404 Not Found`
+
+```json
+{
+  "detail": "stackchan not connected"
+}
+```
+
+### 備考
+
+- 実機側のウェイクワード検出 (`WakeWordEvt`) と同じように扱われます。
+- すでに `talk_session` 実行中でも、イベント自体は内部フラグとして立ちます。
+
+## `POST /v1/stackchan/{stackchan_ip}/speak`
+
+指定した StackChan にテキストを発話させます。
+
+### パスパラメータ
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| `stackchan_ip` | `string` | 対象 StackChan の接続元 IP |
+
+### リクエストボディ
+
+```json
+{
+  "text": "こんにちは"
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+| --- | --- | --- | --- |
+| `text` | `string` | 必須 | 発話させるテキスト |
+
+### 成功レスポンス
+
+- Status: `204 No Content`
+
+### エラーレスポンス
+
+- Status: `404 Not Found`
+
+```json
+{
+  "detail": "stackchan not connected"
+}
+```
+
+### 備考
+
+- サーバーは TTS 音声を WebSocket で送信し、CoreS3 からの `SpeakDoneEvt` を待ってからレスポンスを返します。
+- そのため、この API は「キューに積むだけ」ではなく、発話完了まで待つ同期的な呼び出しです。
+- TTS や WebSocket 処理で例外が起きると、FastAPI の既定エラーハンドリングにより `5xx` になる場合があります。
+
+## 補足
+
+### 接続管理
+
+- 同一 IP から再接続が来た場合、古い `WsProxy` は閉じられ、新しい接続で置き換えられます。
+- REST API は接続中の `WsProxy` を参照して処理します。
+
+### OpenAPI
+
+- FastAPI の標準 UI が有効なら `/docs` と `/openapi.json` も利用できます。
+- 本ドキュメントは実装の要約であり、最終的なレスポンス形状は FastAPI の自動生成スキーマも参照してください。


### PR DESCRIPTION
This pull request provides a major rewrite and expansion of the documentation for the StackChan project, clarifying the roles of firmware and server components, and thoroughly documenting both the WebSocket binary protocol and the REST API. The changes make the project much easier to understand for new developers by organizing information, summarizing key points, and introducing detailed tables and endpoint descriptions.

**Documentation Structure and Clarity Improvements**

* [`AGENTS.md`](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L3-R114): Rewrote the overview to clarify the roles of firmware (`firmware/`) and server (`stackchan_server/`), summarized protocol details, and added concise descriptions of state transitions, WebSocket protocol, and sample apps. Servo control and new protocol events are now documented.
* [`docs/protocols.md`](diffhunk://#diff-b762297a4cb5ceb0eb28370ec273ab0a63364ff869f73f349c61d7b95fb93677L5-R159): Completely reorganized and expanded the WebSocket binary protocol documentation. Added tables for header fields and message kinds, described each protocol message in detail, and included implementation notes for both firmware and server sides.

**New REST API Documentation**

* [`docs/rest-api.md`](diffhunk://#diff-2be1722cf85f9b29bfbb587955653c33cfbdafac0700b9d3eb45d92d62af434eR1-R189): Added a new file documenting the REST API endpoints exposed by the server (`stackchan_server/app.py`). Includes endpoint tables, request/response examples, error handling, and implementation notes.

These changes make the documentation much more accessible, accurate, and comprehensive for both junior and senior engineers.…cations