### PR TITLE
Add SCS0009 servo support with center offset control

### DIFF
--- a/firmware/include/config.template.h
+++ b/firmware/include/config.template.h
@@ -2,9 +2,9 @@
 #define WIFI_PASSWORD_H "__PASSWORD__"
 
 // WebSocket Server
-#define SERVER_HOST_H "192.168.1.179"   // 例: サーバのIP
-#define SERVER_PORT_H 8000              // 例: FastAPIのポート
-#define SERVER_PATH_H "/ws/stackchan"      // WebSocketパス
+#define SERVER_HOST_H "192.168.1.179"  // Example: server IP
+#define SERVER_PORT_H 8000              // Example: FastAPI port
+#define SERVER_PATH_H "/ws/stackchan"  // WebSocket path
 
 // -- using SG90 --
 // #define USE_SERVO_SG90 1
@@ -18,6 +18,10 @@
 // m5pantilt
 // #define SERVO_SG90_X_PIN 7
 // #define SERVO_SG90_Y_PIN 6
+// Center offset added to the logical 90-degree center
+// Positive values bias X to the right and Y upward; negative values bias X to the left and Y downward
+// #define SERVO_SG90_X_CENTER_OFFSET 0
+// #define SERVO_SG90_Y_CENTER_OFFSET 0
 
 // -- using SCS0009 --
 // #define USE_SERVO_SCS0009 1
@@ -28,5 +32,7 @@
 
 // #define SCS0009_X_ID 1
 // #define SCS0009_Y_ID 2
-// #define SCS0009_X_REVERSED 0
-// #define SCS0009_Y_REVERSED 1
+// Center offset added to the logical 90-degree center
+// Positive values bias X to the right and Y upward; negative values bias X to the left and Y downward
+// #define SCS0009_X_CENTER_OFFSET 0
+// #define SCS0009_Y_CENTER_OFFSET 0

--- a/firmware/include/config.template.h
+++ b/firmware/include/config.template.h
@@ -1,7 +1,32 @@
 #define WIFI_SSID_H "__SSID__"
 #define WIFI_PASSWORD_H "__PASSWORD__"
 
-// WebSocket サーバ設定
+// WebSocket Server
 #define SERVER_HOST_H "192.168.1.179"   // 例: サーバのIP
 #define SERVER_PORT_H 8000              // 例: FastAPIのポート
 #define SERVER_PATH_H "/ws/stackchan"      // WebSocketパス
+
+// -- using SG90 --
+// #define USE_SERVO_SG90 1
+
+// CoreS3 PortA
+// #define SERVO_SG90_X_PIN 1
+// #define SERVO_SG90_Y_PIN 2
+// CoreS3 PortC
+// #define SERVO_SG90_X_PIN 18
+// #define SERVO_SG90_Y_PIN 17
+// m5pantilt
+// #define SERVO_SG90_X_PIN 7
+// #define SERVO_SG90_Y_PIN 6
+
+// -- using SCS0009 --
+// #define USE_SERVO_SCS0009 1
+
+// CoreS3 PortC
+// #define SCS_SRIAL_RX_PIN 17
+// #define SCS_SRIAL_TX_PIN 18
+
+// #define SCS0009_X_ID 1
+// #define SCS0009_Y_ID 2
+// #define SCS0009_X_REVERSED 0
+// #define SCS0009_Y_REVERSED 1

--- a/firmware/include/servo.hpp
+++ b/firmware/include/servo.hpp
@@ -1,12 +1,20 @@
 #pragma once
 
-#include <ESP32Servo.h>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <vector>
 
+#include "config.h"
 #include "protocols.hpp"
+
+#if defined(USE_SERVO_SG90)
+#include <ESP32Servo.h>
+#endif
+
+#if defined(USE_SERVO_SCS0009)
+#include <SCServo.h>
+#endif
 
 class BodyServo
 {
@@ -24,7 +32,13 @@ public:
 private:
   struct AxisMotion
   {
+#if defined(USE_SERVO_SG90)
     Servo servo;
+#endif
+#if defined(USE_SERVO_SCS0009)
+    uint8_t scs_id = 0;
+  bool inverted = false;
+#endif
     int16_t current_degree = 90;
     int16_t start_degree = 90;
     int16_t target_degree = 90;
@@ -50,6 +64,9 @@ private:
 
   AxisMotion axis_x_{};
   AxisMotion axis_y_{};
+#if defined(USE_SERVO_SCS0009)
+  SCSCL sc_{};
+#endif
   bool attached_ = false;
 
   std::vector<Step> steps_{};

--- a/firmware/include/servo.hpp
+++ b/firmware/include/servo.hpp
@@ -37,8 +37,9 @@ private:
 #endif
 #if defined(USE_SERVO_SCS0009)
     uint8_t scs_id = 0;
-  bool inverted = false;
+    bool reverse_direction = false;
 #endif
+    int16_t center_offset_degree = 0;
     int16_t current_degree = 90;
     int16_t start_degree = 90;
     int16_t target_degree = 90;

--- a/firmware/src/servo.cpp
+++ b/firmware/src/servo.cpp
@@ -21,6 +21,8 @@ namespace
 #if defined(USE_SERVO_SG90)
 constexpr int kServoXPin = SERVO_SG90_X_PIN;
 constexpr int kServoYPin = SERVO_SG90_Y_PIN;
+constexpr int16_t kServoXCenterOffset = SERVO_SG90_X_CENTER_OFFSET;
+constexpr int16_t kServoYCenterOffset = SERVO_SG90_Y_CENTER_OFFSET;
 constexpr int kServoPulseMinUs = 500;
 constexpr int kServoPulseMaxUs = 2400;
 constexpr int kServoFrequencyHz = 50;
@@ -30,8 +32,10 @@ constexpr uint32_t kEasingDivisionMs = 10;
 #if defined(USE_SERVO_SCS0009)
 constexpr uint8_t kServoXId = SCS0009_X_ID;
 constexpr uint8_t kServoYId = SCS0009_Y_ID;
-constexpr bool kServoXInverted = SCS0009_X_REVERSED != 0;
-constexpr bool kServoYInverted = SCS0009_Y_REVERSED != 0;
+constexpr int16_t kServoXCenterOffset = SCS0009_X_CENTER_OFFSET;
+constexpr int16_t kServoYCenterOffset = SCS0009_Y_CENTER_OFFSET;
+constexpr bool kServoXReverseDirection = false;
+constexpr bool kServoYReverseDirection = true;
 constexpr uint32_t kScsBaudRate = 1000000;
 constexpr uint16_t kScsPositionMin = 0;
 constexpr uint16_t kScsPositionMax = 1023;
@@ -41,6 +45,11 @@ constexpr uint16_t kScsDefaultSpeed = 200;
 int16_t clampDegree(int16_t degree)
 {
   return std::clamp<int16_t>(degree, 0, 180);
+}
+
+int16_t applyCenterOffset(int16_t degree, int16_t offset_degree)
+{
+  return clampDegree(static_cast<int16_t>(degree + offset_degree));
 }
 
 uint32_t clampDuration(int16_t duration_ms)
@@ -56,11 +65,15 @@ int16_t readInt16Le(const uint8_t *src)
 }
 
 #if defined(USE_SERVO_SCS0009)
-uint16_t degreeToScsPosition(int16_t degree, bool inverted)
+int16_t applyScsDirection(int16_t degree, bool reverse_direction)
 {
   const int16_t normalized_degree = clampDegree(degree);
-  const int16_t mapped_degree = inverted ? static_cast<int16_t>(180 - normalized_degree) : normalized_degree;
-  const long position = map(mapped_degree, 0, 180, kScsPositionMin, kScsPositionMax);
+  return reverse_direction ? static_cast<int16_t>(180 - normalized_degree) : normalized_degree;
+}
+
+uint16_t degreeToScsPosition(int16_t degree, bool reverse_direction)
+{
+  const long position = map(applyScsDirection(degree, reverse_direction), 0, 180, kScsPositionMin, kScsPositionMax);
   return static_cast<uint16_t>(std::clamp<long>(position, kScsPositionMin, kScsPositionMax));
 }
 
@@ -80,13 +93,13 @@ void BodyServo::init()
   }
 
 #if defined(USE_SERVO_SG90)
-  axis_x_.servo.write(axis_x_.current_degree);
-  axis_y_.servo.write(axis_y_.current_degree);
+  axis_x_.servo.write(applyCenterOffset(axis_x_.current_degree, axis_x_.center_offset_degree));
+  axis_y_.servo.write(applyCenterOffset(axis_y_.current_degree, axis_y_.center_offset_degree));
 #elif defined(USE_SERVO_SCS0009)
   sc_.PWMMode(axis_x_.scs_id, false);
   sc_.PWMMode(axis_y_.scs_id, false);
-  sc_.WritePos(axis_x_.scs_id, degreeToScsPosition(axis_x_.current_degree, axis_x_.inverted), 0, kScsDefaultSpeed);
-  sc_.WritePos(axis_y_.scs_id, degreeToScsPosition(axis_y_.current_degree, axis_y_.inverted), 0, kScsDefaultSpeed);
+  sc_.WritePos(axis_x_.scs_id, degreeToScsPosition(applyCenterOffset(axis_x_.current_degree, axis_x_.center_offset_degree), axis_x_.reverse_direction), 0, kScsDefaultSpeed);
+  sc_.WritePos(axis_y_.scs_id, degreeToScsPosition(applyCenterOffset(axis_y_.current_degree, axis_y_.center_offset_degree), axis_y_.reverse_direction), 0, kScsDefaultSpeed);
 #endif
 }
 
@@ -254,15 +267,19 @@ bool BodyServo::ensureAttached()
 #if defined(USE_SERVO_SG90)
   axis_x_.servo.setPeriodHertz(kServoFrequencyHz);
   axis_y_.servo.setPeriodHertz(kServoFrequencyHz);
+  axis_x_.center_offset_degree = kServoXCenterOffset;
+  axis_y_.center_offset_degree = kServoYCenterOffset;
 
   const bool x_ok = axis_x_.servo.attach(kServoXPin, kServoPulseMinUs, kServoPulseMaxUs) > 0;
   const bool y_ok = axis_y_.servo.attach(kServoYPin, kServoPulseMinUs, kServoPulseMaxUs) > 0;
   attached_ = x_ok && y_ok;
 #elif defined(USE_SERVO_SCS0009)
   axis_x_.scs_id = kServoXId;
-  axis_x_.inverted = kServoXInverted;
+  axis_x_.reverse_direction = kServoXReverseDirection;
+  axis_x_.center_offset_degree = kServoXCenterOffset;
   axis_y_.scs_id = kServoYId;
-  axis_y_.inverted = kServoYInverted;
+  axis_y_.reverse_direction = kServoYReverseDirection;
+  axis_y_.center_offset_degree = kServoYCenterOffset;
 
   Serial2.begin(kScsBaudRate, SERIAL_8N1, SCS_SRIAL_RX_PIN, SCS_SRIAL_TX_PIN);
   sc_.pSerial = &Serial2;
@@ -289,7 +306,7 @@ void BodyServo::updateAxis(AxisMotion &axis, uint32_t now)
   if (elapsed >= axis.move_duration_ms)
   {
     axis.current_degree = axis.target_degree;
-    axis.servo.write(axis.current_degree);
+    axis.servo.write(applyCenterOffset(axis.current_degree, axis.center_offset_degree));
     axis.moving = false;
     axis.last_update_ms = now;
     return;
@@ -297,7 +314,7 @@ void BodyServo::updateAxis(AxisMotion &axis, uint32_t now)
 
   const float progress = static_cast<float>(elapsed) / static_cast<float>(axis.move_duration_ms);
   axis.current_degree = axis.start_degree + static_cast<int16_t>((axis.target_degree - axis.start_degree) * progress);
-  axis.servo.write(axis.current_degree);
+  axis.servo.write(applyCenterOffset(axis.current_degree, axis.center_offset_degree));
   axis.last_update_ms = now;
 #elif defined(USE_SERVO_SCS0009)
   const uint32_t elapsed = now - axis.move_start_ms;
@@ -324,9 +341,9 @@ void BodyServo::startMove(AxisMotion &axis, int8_t degree, int16_t duration_ms)
   {
     axis.current_degree = axis.target_degree;
 #if defined(USE_SERVO_SG90)
-    axis.servo.write(axis.current_degree);
+    axis.servo.write(applyCenterOffset(axis.current_degree, axis.center_offset_degree));
 #elif defined(USE_SERVO_SCS0009)
-  sc_.WritePos(axis.scs_id, degreeToScsPosition(axis.current_degree, axis.inverted), 0, kScsDefaultSpeed);
+  sc_.WritePos(axis.scs_id, degreeToScsPosition(applyCenterOffset(axis.current_degree, axis.center_offset_degree), axis.reverse_direction), 0, kScsDefaultSpeed);
 #endif
     axis.moving = false;
     return;
@@ -335,7 +352,7 @@ void BodyServo::startMove(AxisMotion &axis, int8_t degree, int16_t duration_ms)
 #if defined(USE_SERVO_SG90)
   axis.moving = true;
 #elif defined(USE_SERVO_SCS0009)
-  sc_.WritePos(axis.scs_id, degreeToScsPosition(axis.target_degree, axis.inverted), clampScsDuration(duration_ms), 0);
+  sc_.WritePos(axis.scs_id, degreeToScsPosition(applyCenterOffset(axis.target_degree, axis.center_offset_degree), axis.reverse_direction), clampScsDuration(duration_ms), 0);
   axis.moving = true;
 #endif
 }

--- a/firmware/src/servo.cpp
+++ b/firmware/src/servo.cpp
@@ -281,8 +281,8 @@ bool BodyServo::ensureAttached()
   axis_y_.reverse_direction = kServoYReverseDirection;
   axis_y_.center_offset_degree = kServoYCenterOffset;
 
-  Serial2.begin(kScsBaudRate, SERIAL_8N1, SCS_SRIAL_RX_PIN, SCS_SRIAL_TX_PIN);
-  sc_.pSerial = &Serial2;
+  Serial1.begin(kScsBaudRate, SERIAL_8N1, SCS_SRIAL_RX_PIN, SCS_SRIAL_TX_PIN);
+  sc_.pSerial = &Serial1;
   attached_ = true;
 #endif
 

--- a/firmware/src/servo.cpp
+++ b/firmware/src/servo.cpp
@@ -1,19 +1,42 @@
 #include "servo.hpp"
+#include "config.h"
 
 #include <M5Unified.h>
 
 #include <algorithm>
 #include <cstring>
+#include <limits>
 #include <utility>
 
 namespace
 {
-constexpr int kServoXPin = 6;
-constexpr int kServoYPin = 7;
+#if defined(USE_SERVO_SG90) && defined(USE_SERVO_SCS0009)
+#error "Define only one of USE_SERVO_SG90 or USE_SERVO_SCS0009"
+#endif
+
+#if !defined(USE_SERVO_SG90) && !defined(USE_SERVO_SCS0009)
+#error "Define one of USE_SERVO_SG90 or USE_SERVO_SCS0009 in config.h"
+#endif
+
+#if defined(USE_SERVO_SG90)
+constexpr int kServoXPin = SERVO_SG90_X_PIN;
+constexpr int kServoYPin = SERVO_SG90_Y_PIN;
 constexpr int kServoPulseMinUs = 500;
 constexpr int kServoPulseMaxUs = 2400;
 constexpr int kServoFrequencyHz = 50;
 constexpr uint32_t kEasingDivisionMs = 10;
+#endif
+
+#if defined(USE_SERVO_SCS0009)
+constexpr uint8_t kServoXId = SCS0009_X_ID;
+constexpr uint8_t kServoYId = SCS0009_Y_ID;
+constexpr bool kServoXInverted = SCS0009_X_REVERSED != 0;
+constexpr bool kServoYInverted = SCS0009_Y_REVERSED != 0;
+constexpr uint32_t kScsBaudRate = 1000000;
+constexpr uint16_t kScsPositionMin = 0;
+constexpr uint16_t kScsPositionMax = 1023;
+constexpr uint16_t kScsDefaultSpeed = 200;
+#endif
 
 int16_t clampDegree(int16_t degree)
 {
@@ -31,6 +54,21 @@ int16_t readInt16Le(const uint8_t *src)
   memcpy(&value, src, sizeof(value));
   return value;
 }
+
+#if defined(USE_SERVO_SCS0009)
+uint16_t degreeToScsPosition(int16_t degree, bool inverted)
+{
+  const int16_t normalized_degree = clampDegree(degree);
+  const int16_t mapped_degree = inverted ? static_cast<int16_t>(180 - normalized_degree) : normalized_degree;
+  const long position = map(mapped_degree, 0, 180, kScsPositionMin, kScsPositionMax);
+  return static_cast<uint16_t>(std::clamp<long>(position, kScsPositionMin, kScsPositionMax));
+}
+
+uint16_t clampScsDuration(int16_t duration_ms)
+{
+  return static_cast<uint16_t>(std::min<uint32_t>(clampDuration(duration_ms), std::numeric_limits<uint16_t>::max()));
+}
+#endif
 } // namespace
 
 void BodyServo::init()
@@ -41,8 +79,15 @@ void BodyServo::init()
     return;
   }
 
+#if defined(USE_SERVO_SG90)
   axis_x_.servo.write(axis_x_.current_degree);
   axis_y_.servo.write(axis_y_.current_degree);
+#elif defined(USE_SERVO_SCS0009)
+  sc_.PWMMode(axis_x_.scs_id, false);
+  sc_.PWMMode(axis_y_.scs_id, false);
+  sc_.WritePos(axis_x_.scs_id, degreeToScsPosition(axis_x_.current_degree, axis_x_.inverted), 0, kScsDefaultSpeed);
+  sc_.WritePos(axis_y_.scs_id, degreeToScsPosition(axis_y_.current_degree, axis_y_.inverted), 0, kScsDefaultSpeed);
+#endif
 }
 
 void BodyServo::loop()
@@ -206,12 +251,24 @@ bool BodyServo::ensureAttached()
     return true;
   }
 
+#if defined(USE_SERVO_SG90)
   axis_x_.servo.setPeriodHertz(kServoFrequencyHz);
   axis_y_.servo.setPeriodHertz(kServoFrequencyHz);
 
   const bool x_ok = axis_x_.servo.attach(kServoXPin, kServoPulseMinUs, kServoPulseMaxUs) > 0;
   const bool y_ok = axis_y_.servo.attach(kServoYPin, kServoPulseMinUs, kServoPulseMaxUs) > 0;
   attached_ = x_ok && y_ok;
+#elif defined(USE_SERVO_SCS0009)
+  axis_x_.scs_id = kServoXId;
+  axis_x_.inverted = kServoXInverted;
+  axis_y_.scs_id = kServoYId;
+  axis_y_.inverted = kServoYInverted;
+
+  Serial2.begin(kScsBaudRate, SERIAL_8N1, SCS_SRIAL_RX_PIN, SCS_SRIAL_TX_PIN);
+  sc_.pSerial = &Serial2;
+  attached_ = true;
+#endif
+
   return attached_;
 }
 
@@ -222,6 +279,7 @@ void BodyServo::updateAxis(AxisMotion &axis, uint32_t now)
     return;
   }
 
+#if defined(USE_SERVO_SG90)
   const uint32_t elapsed = now - axis.move_start_ms;
   if ((now - axis.last_update_ms) < kEasingDivisionMs && elapsed < axis.move_duration_ms)
   {
@@ -241,6 +299,17 @@ void BodyServo::updateAxis(AxisMotion &axis, uint32_t now)
   axis.current_degree = axis.start_degree + static_cast<int16_t>((axis.target_degree - axis.start_degree) * progress);
   axis.servo.write(axis.current_degree);
   axis.last_update_ms = now;
+#elif defined(USE_SERVO_SCS0009)
+  const uint32_t elapsed = now - axis.move_start_ms;
+  if (elapsed < axis.move_duration_ms)
+  {
+    return;
+  }
+
+  axis.current_degree = axis.target_degree;
+  axis.last_update_ms = now;
+  axis.moving = false;
+#endif
 }
 
 void BodyServo::startMove(AxisMotion &axis, int8_t degree, int16_t duration_ms)
@@ -254,12 +323,21 @@ void BodyServo::startMove(AxisMotion &axis, int8_t degree, int16_t duration_ms)
   if (axis.move_duration_ms == 0 || axis.start_degree == axis.target_degree)
   {
     axis.current_degree = axis.target_degree;
+#if defined(USE_SERVO_SG90)
     axis.servo.write(axis.current_degree);
+#elif defined(USE_SERVO_SCS0009)
+  sc_.WritePos(axis.scs_id, degreeToScsPosition(axis.current_degree, axis.inverted), 0, kScsDefaultSpeed);
+#endif
     axis.moving = false;
     return;
   }
 
+#if defined(USE_SERVO_SG90)
   axis.moving = true;
+#elif defined(USE_SERVO_SCS0009)
+  sc_.WritePos(axis.scs_id, degreeToScsPosition(axis.target_degree, axis.inverted), clampScsDuration(duration_ms), 0);
+  axis.moving = true;
+#endif
 }
 
 void BodyServo::startCurrentStep(uint32_t now)

--- a/platformio.ini
+++ b/platformio.ini
@@ -62,6 +62,7 @@ lib_deps =
     ESP32Async/AsyncTCP@^3.4.10
     madhephaestus/ESP32Servo@^3.1.3
     https://github.com/74th/ESP-SR-For-M5Unified.git@1.0.0
+    https://github.com/mongonta0716/SCServo.git
 
 lib_ldf_mode = deep
 


### PR DESCRIPTION
## Summary
- add support for switching between SG90 and SCS0009 servo control in the firmware
- implement SCS0009 control over serial with fixed Y-axis reversal to match the assembled hardware
- add configurable center offsets for both SG90 and SCS0009 and document the settings in the config templates

## Testing
- `/Users/nnyn/bin/pio run -e m5stack-cores3-m5unified`

## Notes
- the branch currently has a few untracked local files (such as prompt/test helper files), but they are not part of this pull request because they are not committed