### PR TITLE
Enhance CI workflows for linting, type checking, and PlatformIO build

### DIFF
--- a/.github/workflows/pr-lint-typecheck.yml
+++ b/.github/workflows/pr-lint-typecheck.yml
@@ -6,15 +6,25 @@ on:
       - main
     paths:
       - ".github/workflows/pr-lint-typecheck.yml"
+      - "Makefile"
+      - "platformio.ini"
+      - "platformio-m5stack.ini"
       - "pyproject.toml"
+      - "protobuf/**"
       - "uv.lock"
+      - "firmware/lib/generated_protobuf/**"
       - "stackchan_server/**"
       - "example_apps/**"
   pull_request:
     paths:
       - ".github/workflows/pr-lint-typecheck.yml"
+      - "Makefile"
+      - "platformio.ini"
+      - "platformio-m5stack.ini"
       - "pyproject.toml"
+      - "protobuf/**"
       - "uv.lock"
+      - "firmware/lib/generated_protobuf/**"
       - "stackchan_server/**"
       - "example_apps/**"
 
@@ -42,3 +52,14 @@ jobs:
 
       - name: ty
         run: uv run ty check stackchan_server example_apps
+
+      - name: Install PlatformIO
+        run: python -m pip install platformio
+
+      - name: Verify generated protobuf files are up to date
+        run: |
+          set -euo pipefail
+          pio pkg install -e m5stack-cores3-m5unified
+          make protobuf
+          git diff --stat -- stackchan_server/generated_protobuf firmware/lib/generated_protobuf
+          git diff --exit-code -- stackchan_server/generated_protobuf firmware/lib/generated_protobuf

--- a/.github/workflows/pr-lint-typecheck.yml
+++ b/.github/workflows/pr-lint-typecheck.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
     paths:
       - ".github/workflows/pr-lint-typecheck.yml"
       - "Makefile"

--- a/.github/workflows/pr-platformio-build.yml
+++ b/.github/workflows/pr-platformio-build.yml
@@ -1,0 +1,41 @@
+name: PR PlatformIO Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/pr-platformio-build.yml"
+      - "platformio.ini"
+      - "platformio-m5stack.ini"
+      - "protobuf/**"
+      - "firmware/**"
+  pull_request:
+    paths:
+      - ".github/workflows/pr-platformio-build.yml"
+      - "platformio.ini"
+      - "platformio-m5stack.ini"
+      - "protobuf/**"
+      - "firmware/**"
+
+jobs:
+  platformio-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install PlatformIO
+        run: python -m pip install platformio
+
+      - name: Prepare firmware config
+        run: cp firmware/include/config.template.h firmware/include/config.h
+
+      - name: Build firmware
+        run: pio run --environment m5stack-cores3-m5unified

--- a/.github/workflows/pr-platformio-build.yml
+++ b/.github/workflows/pr-platformio-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
     paths:
       - ".github/workflows/pr-platformio-build.yml"
       - "platformio.ini"

--- a/firmware/include/config.template.h
+++ b/firmware/include/config.template.h
@@ -23,8 +23,8 @@
 // #define SERVO_SG90_Y_PIN 6
 // Center offset added to the logical 90-degree center
 // Positive values bias X to the right and Y upward; negative values bias X to the left and Y downward
-// #define SERVO_SG90_X_CENTER_OFFSET 0
-// #define SERVO_SG90_Y_CENTER_OFFSET 0
+#define SERVO_SG90_X_CENTER_OFFSET 0
+#define SERVO_SG90_Y_CENTER_OFFSET 0
 
 // -- using SCS0009 --
 // #define USE_SERVO_SCS0009 1


### PR DESCRIPTION
This pull request improves CI coverage for firmware and protobuf changes by updating and adding GitHub Actions workflows, as well as enabling servo center offset configuration in the firmware. The main changes include expanding the typecheck workflow to cover more files, introducing a dedicated PlatformIO build workflow, and ensuring that generated protobuf files are always up to date.

**CI workflow improvements:**

* Expanded the `.github/workflows/pr-lint-typecheck.yml` workflow to trigger on changes to additional files and directories, including `Makefile`, `platformio.ini`, `protobuf/**`, and firmware-related paths, ensuring more comprehensive lint and typecheck coverage.
* Added steps to the typecheck workflow to install PlatformIO and verify that generated protobuf files in `stackchan_server/generated_protobuf` and `firmware/lib/generated_protobuf` are up to date, failing the job if not.
* Introduced a new `.github/workflows/pr-platformio-build.yml` workflow that builds the firmware using PlatformIO on every relevant push or pull request, ensuring build integrity for firmware changes.

**Firmware configuration:**

* Enabled the `SERVO_SG90_X_CENTER_OFFSET` and `SERVO_SG90_Y_CENTER_OFFSET` definitions by default in `firmware/include/config.template.h`, allowing servo center offsets to be configured without manual uncommenting.