### PR TITLE
feat: update CI build configuration to use matrix strategy for enviro…

### DIFF
--- a/.github/workflows/pr-platformio-build.yml
+++ b/.github/workflows/pr-platformio-build.yml
@@ -22,6 +22,11 @@ on:
 jobs:
   platformio-build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment:
+          - m5stack-official-stackchan
+          - m5stack-cores3-m5unified
 
     steps:
       - name: Checkout
@@ -39,4 +44,4 @@ jobs:
         run: cp firmware/include/config.template.h firmware/include/config.h
 
       - name: Build firmware
-        run: pio run --environment m5stack-cores3-m5unified
+        run: pio run --environment ${{ matrix.environment }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building firmware with PlatformIO. The main improvement is adding a build matrix to automatically build the firmware for multiple environments, making the CI process more robust and comprehensive.

**CI/CD improvements:**

* Added a build matrix to the `platformio-build` job in `.github/workflows/pr-platformio-build.yml`, enabling builds for both `m5stack-official-stackchan` and `m5stack-cores3-m5unified` environments.
* Updated the build step to use the matrix environment variable, so the workflow runs the build for each specified environment.