### PR TITLE
Add workflows for version bump checks and release management

### DIFF
--- a/.github/workflows/check-version-bump-for-main-pr.yml
+++ b/.github/workflows/check-version-bump-for-main-pr.yml
@@ -1,0 +1,75 @@
+name: Check Version Bump For Main Or Test PR
+
+on:
+  pull_request:
+    branches:
+      - main
+      - test
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  check-version-bump:
+    if: github.head_ref == 'develop'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Compare pyproject.toml versions
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          git fetch origin "${BASE_REF}" --depth=1
+          python - <<'PY'
+          import os
+          import subprocess
+          import tomllib
+          from pathlib import Path
+
+          def read_version(pyproject_text: str) -> str:
+              data = tomllib.loads(pyproject_text)
+              version = data.get("project", {}).get("version")
+              if not version:
+                  raise SystemExit("project.version not found in pyproject.toml")
+              return version
+
+          base_ref = os.environ["BASE_REF"]
+          head_ref = os.environ["HEAD_REF"]
+          base_pyproject = subprocess.check_output(
+              ["git", "show", f"origin/{base_ref}:pyproject.toml"],
+              text=True,
+          )
+          head_pyproject = Path("pyproject.toml").read_text()
+
+          base_version = read_version(base_pyproject)
+          head_version = read_version(head_pyproject)
+
+          print(f"Base branch version ({base_ref}): {base_version}")
+          print(f"PR branch version ({head_ref}): {head_version}")
+
+          if base_version == head_version:
+              print(
+                  f"::error file=pyproject.toml,title=Version bump required::"
+                  f"develop -> {base_ref} PR must update [project].version in pyproject.toml. "
+                  f"{base_ref} is {base_version} and this PR is still {head_version}."
+              )
+              raise SystemExit(1)
+          PY

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -1,0 +1,145 @@
+name: Release On Main Or Test
+
+on:
+  push:
+    branches:
+      - main
+      - test
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Read release version from pyproject.toml
+        id: version
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path("pyproject.toml").read_text())
+          version = data["project"]["version"]
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              print(f"tag={version}", file=fh)
+
+          print(f"Release version: {version}")
+          PY
+
+      - name: Find previous version tag
+        id: previous
+        shell: bash
+        run: |
+          set -euo pipefail
+          current_tag="${{ steps.version.outputs.tag }}"
+          previous_tag="$(git tag --list '[0-9]*' --sort=-version:refname | grep -Fxv "${current_tag}" | head -n 1 || true)"
+          echo "previous_tag=${previous_tag}" >> "$GITHUB_OUTPUT"
+          if [ -n "${previous_tag}" ]; then
+            echo "Previous tag: ${previous_tag}"
+          else
+            echo "Previous tag: none"
+          fi
+
+      - name: Create tag if needed
+        uses: actions/github-script@v7
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          TARGET_SHA: ${{ github.sha }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const tag = process.env.TAG;
+            const targetSha = process.env.TARGET_SHA;
+
+            try {
+              await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: `tags/${tag}`,
+              });
+              core.notice(`Tag ${tag} already exists.`);
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: `refs/tags/${tag}`,
+                sha: targetSha,
+              });
+              core.notice(`Created tag ${tag} at ${targetSha}.`);
+            }
+
+      - name: Create GitHub Release if needed
+        uses: actions/github-script@v7
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          PREVIOUS_TAG: ${{ steps.previous.outputs.previous_tag }}
+          TARGET_SHA: ${{ github.sha }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const tag = process.env.TAG;
+            const previousTag = process.env.PREVIOUS_TAG;
+            const targetSha = process.env.TARGET_SHA;
+
+            try {
+              const existing = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag,
+              });
+              core.notice(`Release for ${tag} already exists: ${existing.data.html_url}`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            const notes = await github.request(
+              "POST /repos/{owner}/{repo}/releases/generate-notes",
+              {
+                owner,
+                repo,
+                tag_name: tag,
+                target_commitish: targetSha,
+                ...(previousTag ? { previous_tag_name: previousTag } : {}),
+              },
+            );
+
+            const release = await github.rest.repos.createRelease({
+              owner,
+              repo,
+              tag_name: tag,
+              target_commitish: targetSha,
+              name: tag,
+              body: notes.data.body,
+              draft: false,
+              prerelease: false,
+              generate_release_notes: false,
+            });
+
+            core.notice(`Created release ${release.data.html_url}`);


### PR DESCRIPTION

This pull request introduces two new GitHub Actions workflows to automate version bump checks and releases for the `main` and `test` branches. These workflows help enforce versioning best practices and streamline the release process by automatically checking for required version updates and creating tags and GitHub releases as needed.

**New GitHub Actions workflows:**

*Version bump enforcement:*
- Adds `.github/workflows/check-version-bump-for-main-pr.yml` to ensure that any pull request from `develop` to `main` or `test` includes a version bump in `pyproject.toml`. If the version is not updated, the workflow fails and provides an error message.

*Automated release process:*
- Adds `.github/workflows/release-on-main.yml` to automatically create a new Git tag and GitHub Release when changes are pushed to `main` or `test`. The workflow reads the version from `pyproject.toml`, checks for existing tags/releases, and generates release notes if a new release is needed.